### PR TITLE
Fix EditCommand to retain Driver assignments for edited Person

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -25,6 +25,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.commons.name.Name;
 import seedu.address.model.commons.phone.Phone;
+import seedu.address.model.delivery.Driver;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Box;
 import seedu.address.model.person.DeliveryStatus;
@@ -114,8 +115,17 @@ public class EditCommand extends Command {
         Set<Box> updatedBoxes = personToEdit.getBoxes();
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedBoxes,
-                updatedRemark, updatedDeliveryStatus, updatedTags);
+        // Re-use the existing assigned driver is address is unchanged
+        if (editPersonDescriptor.getAddress().isEmpty()) {
+            Driver preassignedDriver = personToEdit.getAssignedDriver();
+            return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedBoxes,
+                    updatedRemark, updatedDeliveryStatus, updatedTags, preassignedDriver);
+        } else {
+            // Edited Person has new address, so we create a Person without any Driver assigned
+            return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedBoxes,
+                    updatedRemark, updatedDeliveryStatus, updatedTags);
+        }
+
     }
 
     @Override


### PR DESCRIPTION
Fixes #190 

Updated EditCommand to use overloaded constructor to assign the previously assigned Driver to the PersonToEdit. We will not re-use Driver when there is a change in Address! ExportCommand should flag out when all Persons have not been assigned.


<img width="668" height="599" alt="image" src="https://github.com/user-attachments/assets/9246a0eb-adf6-4057-9436-154e5026cb8d" />
