### PR TITLE
Filter non-delivered persons to be grouped in the assign command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AssignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignCommand.java
@@ -46,8 +46,6 @@ public class AssignCommand extends Command {
      * Creates an AssignCommand to tag all {@code Person}s to a {@code Driver}
      */
     public AssignCommand(Driver... inputDrivers) throws CommandException {
-        DeliveryAssignmentHashMap.clearAssignments();
-
         this.drivers = new Driver[inputDrivers.length];
 
         for (int i = 0; i < inputDrivers.length; i++) {
@@ -72,6 +70,8 @@ public class AssignCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
+        DeliveryAssignmentHashMap.clearAssignments();
+
         requireNonNull(model);
         int numOfDrivers = drivers.length;
 

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.commons.name.Name;
 import seedu.address.model.commons.phone.Phone;
+import seedu.address.model.delivery.Driver;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Box;
 import seedu.address.model.person.DeliveryStatus;
@@ -97,8 +98,12 @@ public class MarkCommand extends Command {
         Remark remarkCopy = personToMark.getRemark();
         Set<Tag> tagsCopy = personToMark.getTags();
 
+        Driver driverCopy = newDeliveryStatus == DeliveryStatus.DELIVERED
+                ? null
+                : personToMark.getAssignedDriver();
+
         return new Person(nameCopy, phoneCopy, emailCopy, addressCopy,
-                boxesCopy, remarkCopy, newDeliveryStatus, tagsCopy);
+                boxesCopy, remarkCopy, newDeliveryStatus, tagsCopy, driverCopy);
     }
 
     @Override


### PR DESCRIPTION
Fix #224 

- Added a filter to get all non-delivered persons that the cluster algorithm will work on, so that those already delivered will not get a redundant assignment