### PR TITLE
docs: Update multiplicity for JsonAdaptedBox

### DIFF
--- a/docs/diagrams/StorageClassDiagram.puml
+++ b/docs/diagrams/StorageClassDiagram.puml
@@ -41,7 +41,7 @@ JsonAddressBookStorage .up.|> AddressBookStorage
 JsonAddressBookStorage ..> JsonSerializableAddressBook
 JsonSerializableAddressBook --> "*" JsonAdaptedPerson
 JsonAdaptedPerson --> "*" JsonAdaptedTag
-JsonAdaptedPerson --> "*" JsonAdaptedBox
+JsonAdaptedPerson --> "1..*" JsonAdaptedBox
 JsonAdaptedPerson --> "0..1" JsonAdaptedDriver
 
 @enduml


### PR DESCRIPTION
## Changes
As per title. Changes are under `StorageClassDiagram`. Previously, diagram states that `JsonAdaptedPerson` could have no boxes, which is not true since the person will get deleted.

## Docs
Refer to changes